### PR TITLE
Fix PSUseSingularNouns warnings and add aliases for old PluralNouns

### DIFF
--- a/Src/LabConfiguration.ps1
+++ b/Src/LabConfiguration.ps1
@@ -104,12 +104,12 @@ function Start-LabConfiguration {
         on the node hashtable in the PowerShell DSC configuration document. Default settings include the Operating
         System image to use, the amount of memory assigned to the virtual machine and/or the virtual switch to
         connect the virtual machine to. If the settings are not overridden, the module's defaults are used. Use the
-        Get-LabVMDefaults cmdlet to view the module's default values.
+        Get-LabVMDefault cmdlet to view the module's default values.
         
         Each virtual machine created by the Start-LabConfiguration cmdlet, has its PowerShell DSC configuraion (.mof)
         file injected into the VHD file as it is created. This configuration is then applied during the first boot
         process to ensure the virtual machine is configured as required. If the path to the VM's .mof files is not
-        specified, the module's default Configuration directory is used. Use the Get-LabHostDefaults cmdlet to view
+        specified, the module's default Configuration directory is used. Use the Get-LabHostDefault cmdlet to view
         the module's default Configuration directory path.
         
         The virtual machine .mof files must be created before creating the lab. If any .mof files are missing, the
@@ -156,10 +156,10 @@ function Start-LabConfiguration {
     .LINK
         about_ConfigurationData
         about_Bootstrap
-        Get-LabHostDefaults
-        Get-LabHostDefaults
-        Get-LabVMDefaults
-        Set-LabVMDefaults
+        Get-LabHostDefault
+        Set-LabHostDefault
+        Get-LabVMDefault
+        Set-LabVMDefault
         Reset-Lab
 #>
     [CmdletBinding(DefaultParameterSetName = 'PSCredential')]

--- a/Src/LabHostConfiguration.ps1
+++ b/Src/LabHostConfiguration.ps1
@@ -6,7 +6,7 @@ function GetLabHostSetupConfiguration {
         The GetLabHostSetupConfiguration function returns an array of hashtables used to determine whether the
         host is in the desired configuration.
     .NOTES
-        The configuration is passed to avoid repeated calls to Get-LabHostDefaults and polluting verbose output.
+        The configuration is passed to avoid repeated calls to Get-LabHostDefault and polluting verbose output.
 #>
     [CmdletBinding()]
     [OutputType([System.Array])]

--- a/Src/LabHostDefaults.ps1
+++ b/Src/LabHostDefaults.ps1
@@ -1,4 +1,4 @@
-function Reset-LabHostDefaults {
+function Reset-LabHostDefault {
 <#
 	.SYNOPSIS
 		Reset the current Hyper-V host default settings back to defaults.
@@ -8,11 +8,12 @@ function Reset-LabHostDefaults {
 	param ( )
     process {
         RemoveConfigurationData -Configuration Host;
-        Get-LabHostDefaults;
+        Get-LabHostDefault;
     }
-} #end function Reset-LabHostDefaults
+} #end function Reset-LabHostDefault
+New-Alias -Name Reset-LabHostDefaults -Value Reset-LabHostDefault
 
-function Get-LabHostDefaults {
+function Get-LabHostDefault {
 <#
 	.SYNOPSIS
 		Gets the current Hyper-V host default settings.
@@ -23,7 +24,8 @@ function Get-LabHostDefaults {
     process {
         GetConfigurationData -Configuration Host;
     }
-} #end function Get-LabHostDefaults
+} #end function Get-LabHostDefault
+New-Alias -Name Get-LabHostDefaults -Value Get-LabHostDefault
 
 function GetLabHostDSCConfigurationPath {
 <#
@@ -39,7 +41,7 @@ function GetLabHostDSCConfigurationPath {
     }
 } #end function GetLabHostDSCConfigurationPath
 
-function Set-LabHostDefaults {
+function Set-LabHostDefault {
 <#
 	.SYNOPSIS
 		Sets the current Hyper-V host default settings.
@@ -95,4 +97,5 @@ function Set-LabHostDefaults {
 		SetConfigurationData -Configuration Host -InputObject $hostDefaults;
 		return $hostDefaults;
 	}
-} #end function Set-LabHostDefaults
+} #end function Set-LabHostDefault
+New-Alias -Name Set-LabHostDefaults -Value Set-LabHostDefault

--- a/Src/LabMedia.ps1
+++ b/Src/LabMedia.ps1
@@ -419,4 +419,4 @@ function Reset-LabMedia {
         RemoveConfigurationData -Configuration CustomMedia;
         Get-Labmedia;
     }
-} #end function Reset-LabHostDefaults
+} #end function Reset-LabMedia

--- a/Src/LabVMDefaults.ps1
+++ b/Src/LabVMDefaults.ps1
@@ -1,4 +1,4 @@
-function Reset-LabVMDefaults {
+function Reset-LabVMDefault {
 <#
 	.SYNOPSIS
 		Reset the current lab virtual machine default settings back to defaults.
@@ -8,11 +8,12 @@ function Reset-LabVMDefaults {
 	param ( )
     process {
         RemoveConfigurationData -Configuration VM;
-        Get-LabVMDefaults;
+        Get-LabVMDefault;
     }
-} #end function Reset-LabVMDefaults
+} #end function Reset-LabVMDefault
+New-Alias -Name Reset-LabVMDefaults -Value Reset-LabVMDefault
 
-function Get-LabVMDefaults {
+function Get-LabVMDefault {
 <#
 	.SYNOPSIS
 		Gets the current lab virtual machine default settings.
@@ -22,13 +23,14 @@ function Get-LabVMDefaults {
 	param ( )
     process {
         $labDefaults = GetConfigurationData -Configuration VM;
-        ## BootOrder property should not be exposed via the Get-LabVMDefaults/Set-LabVMDefaults
+        ## BootOrder property should not be exposed via the Get-LabVMDefault/Set-LabVMDefault
         $labDefaults.PSObject.Properties.Remove('BootOrder');
         return $labDefaults;
     }
-} #end function Get-LabVMDefaults
+} #end function Get-LabVMDefault
+New-Alias -Name Get-LabVMDefaults -Value Get-LabVMDefault
 
-function Set-LabVMDefaults {
+function Set-LabVMDefault {
 <#
 	.SYNOPSIS
 		Sets the lab virtual machine default settings.
@@ -146,9 +148,9 @@ function Set-LabVMDefaults {
 		}
 		
 		SetConfigurationData -Configuration VM -InputObject $vmDefaults;
-        ## BootOrder property should not be exposed via the Get-LabVMDefaults/Set-LabVMDefaults
+        ## BootOrder property should not be exposed via the Get-LabVMDefault/Set-LabVMDefault
         $vmDefaults.PSObject.Properties.Remove('BootOrder');		
         return $vmDefaults;
     }
-} #end function Set-LabVMDefaults
-    
+} #end function Set-LabVMDefault
+New-Alias -Name Set-LabVMDefaults -Value Set-LabVMDefault

--- a/Tests/Src/LabHostDefaults.Tests.ps1
+++ b/Tests/Src/LabHostDefaults.Tests.ps1
@@ -13,17 +13,17 @@ Describe 'LabHostDefaults' {
 
     InModuleScope $moduleName {
 
-        Context 'Validates "Get-LabHostDefaults" method' {
+        Context 'Validates "Get-LabHostDefault" method' {
 
             It 'Calls "GetConfigurationData"' {
                 Mock GetConfigurationData -ParameterFilter { $Configuration -eq 'Host' } -MockWith { }
                 
-                Get-LabHostDefaults;
+                Get-LabHostDefault;
 
                 Assert-MockCalled GetConfigurationData -ParameterFilter { $Configuration -eq 'Host' }
             }
 
-        } #end context Validates "Get-LabHostDefaults" method
+        } #end context Validates "Get-LabHostDefault" method
 
         Context 'Validates "GetLabHostDSCConfigurationPath" method' {
 
@@ -36,7 +36,7 @@ Describe 'LabHostDefaults' {
 
         } #end context Validates "GetLabHostDSCConfigurationPath" method
 
-        Context 'Validates "Set-LabHostDefaults" method' {
+        Context 'Validates "Set-LabHostDefault" method' {
 
             $fakeConfigurationDataObject = ConvertFrom-Json -InputObject '{
                 "ConfigurationPath": "", "DifferencingVhdPath": "", "HotfixPath": "", "IsoPath": "",
@@ -50,7 +50,7 @@ Describe 'LabHostDefaults' {
                 Mock SetConfigurationData -MockWith { Write-Host $InputObject.IsoPath -ForegroundColor Yellow; }
                 Mock SetConfigurationData -ParameterFilter { $InputObject.IsoPath -eq $testResolvedPath } -MockWith { }
 
-                Set-LabHostDefaults -IsoPath $testEnvironmentPath;
+                Set-LabHostDefault -IsoPath $testEnvironmentPath;
 
                 Assert-MockCalled SetConfigurationData -ParameterFilter { $InputObject.IsoPath -eq $testResolvedPath } -Scope It;
             }
@@ -65,7 +65,7 @@ Describe 'LabHostDefaults' {
                     Mock SetConfigurationData -ParameterFilter { $InputObject.$parameter -eq $testValidPath } -MockWith { }
 
                     $setLabHostDefaultsParams = @{ $parameter = $testPath; }
-                    Set-LabHostDefaults @setLabHostDefaultsParams;
+                    Set-LabHostDefault @setLabHostDefaultsParams;
 
                     Assert-MockCalled SetConfigurationData -ParameterFilter { $InputObject.$parameter -eq $testValidPath } -Scope It;
                 }
@@ -77,7 +77,7 @@ Describe 'LabHostDefaults' {
                     Mock SetConfigurationData -MockWith {  }
                     Mock SetConfigurationData -ParameterFilter { $InputObject.ResourceShareName -eq $testShareName } -MockWith { }
 
-                    Set-LabHostDefaults -ResourceShareName $testShareName;
+                    Set-LabHostDefault -ResourceShareName $testShareName;
 
                     Assert-MockCalled SetConfigurationData -ParameterFilter { $InputObject.ResourceShareName -eq $testShareName } -Scope It;
                 }
@@ -87,10 +87,10 @@ Describe 'LabHostDefaults' {
                 Mock GetConfigurationData -ParameterFilter { $Configuration -eq 'Host' } -MockWith { return $fakeConfigurationDataObject; }
                 Mock SetConfigurationData -MockWith { }
 
-                { Set-LabHostDefaults -IsoPath $testInvalidPath } | Should Throw;
+                { Set-LabHostDefault -IsoPath $testInvalidPath } | Should Throw;
             }
             
-        } #end context Validates "Set-LabHostDefaults" method
+        } #end context Validates "Set-LabHostDefault" method
 
     } #end InModuleScope
 

--- a/Tests/Src/LabResource.Tests.ps1
+++ b/Tests/Src/LabResource.Tests.ps1
@@ -13,7 +13,7 @@ Describe 'LabResource' {
 
     InModuleScope $moduleName {
 
-        Context 'Validates "Get-LabHostDefaults" method' {
+        Context 'Validates "Get-LabHostDefault" method' {
             
             $configurationData = @{
                 NonNodeData = @{
@@ -124,7 +124,7 @@ Describe 'LabResource' {
                 Assert-MockCalled TestResourceDownload -ParameterFilter { $Checksum -eq $testResourceChecksum } -Scope It;
             }
 
-        } #end context Validates "Get-LabHostDefaults" method
+        } #end context Validates "Get-LabHostDefault" method
 
         Context 'Validates "Invoke-LabResourceDownload" method' {
 

--- a/Tests/Src/LabVM.Tests.ps1
+++ b/Tests/Src/LabVM.Tests.ps1
@@ -85,7 +85,7 @@ Describe 'LabVM' {
                     )
                 }
 
-                $hostDefaultProperties = Get-LabVMDefaults;
+                $hostDefaultProperties = Get-LabVMDefault;
                 $vmProperties = ResolveLabVMProperties -ConfigurationData $configurationData -NodeName $testVMName -NoEnumerateWildcardNode;
 
                 $vmProperties.ProcessorCount | Should Be $hostDefaultProperties.ProcessorCount;
@@ -99,7 +99,7 @@ Describe 'LabVM' {
                     )
                 }
 
-                $hostDefaultProperties = Get-LabVMDefaults;
+                $hostDefaultProperties = Get-LabVMDefault;
                 $vmProperties = ResolveLabVMProperties -ConfigurationData $configurationData -NodeName $testVMName;
 
                 $vmProperties.ProcessorCount | Should Be $hostDefaultProperties.ProcessorCount;

--- a/Tests/Src/LabVMDefaults.Tests.ps1
+++ b/Tests/Src/LabVMDefaults.Tests.ps1
@@ -13,27 +13,27 @@ Describe 'LabVMDefaults' {
 
     InModuleScope $moduleName {
 
-        Context 'Validates "Get-LabVMDefaults" method' {
+        Context 'Validates "Get-LabVMDefault" method' {
 
             It 'Returns a "System.Management.Automation.PSCustomObject" object type' {
-                $defaults = Get-LabVMDefaults;
+                $defaults = Get-LabVMDefault;
                 
                 $defaults -is [System.Management.Automation.PSCustomObject] | Should Be $true;
             }
 
             It 'Does not return "BootOrder" property' {
-                $defaults = Get-LabVMDefaults;
+                $defaults = Get-LabVMDefault;
 
                 $defaults.BootOrder | Should BeNullOrEmpty;
             }
 
-        } #end context Validates "Get-LabVMDefaults" method
+        } #end context Validates "Get-LabVMDefault" method
         
-        Context 'Validates "Set-LabVMDefaults" method' {
+        Context 'Validates "Set-LabVMDefault" method' {
 
             It 'Does not return "BootOrder" property' {
                 Mock SetConfigurationData -MockWith { }
-                $defaults = Set-LabVMDefaults;
+                $defaults = Set-LabVMDefault;
 
                 $defaults.BootOrder | Should BeNullOrEmpty;
             }
@@ -58,7 +58,7 @@ Describe 'LabVMDefaults' {
             foreach ($property in $testProperties) {
                 It "Sets ""$($property.Keys[0])"" value" {
                     Mock SetConfigurationData -MockWith { }
-                    $defaults = Set-LabVMDefaults @property;
+                    $defaults = Set-LabVMDefault @property;
 
                     $defaults.($property.Keys[0]) | Should Be $property.Values[0];
                 }
@@ -72,41 +72,41 @@ Describe 'LabVMDefaults' {
                 It "Sets ""$($file.Keys[0])"" value" {
                     Mock SetConfigurationData -MockWith { }
                     New-Item -Path $file.Values[0] -Force -ErrorAction SilentlyContinue -ItemType File;
-                    $defaults = Set-LabVMDefaults @file;
+                    $defaults = Set-LabVMDefault @file;
                     
                     $defaults.($file.Keys[0]) | Should Be $file.Values[0];
                 }
             }
 
             It 'Throws if "Timezone" cannot be resolved' {
-                { Set-LabVMDefaults -Timezone 'Cloud cockoo land' } | Should Throw;
+                { Set-LabVMDefault -Timezone 'Cloud cockoo land' } | Should Throw;
             }
 
             It 'Throws if "ClientCertificatePath" file cannot be found' {
-                { Set-LabVMDefaults -ClientCertificatePath 'TestDrive:\ClientCertificate.cer' } | Should Throw;
+                { Set-LabVMDefault -ClientCertificatePath 'TestDrive:\ClientCertificate.cer' } | Should Throw;
             }
 
             It 'Throws if "RootCertificatePath" file cannot be found' {
-                { Set-LabVMDefaults -RootCertificatePath 'TestDrive:\RootCertificate.cer' } | Should Throw;
+                { Set-LabVMDefault -RootCertificatePath 'TestDrive:\RootCertificate.cer' } | Should Throw;
             }
 
             It 'Throws if "StartupMemory" is less than "MinimumMemory"' {
-                { Set-LabVMDefaults -StartupMemory 1GB -MinimumMemory 2GB } | Should Throw;
+                { Set-LabVMDefault -StartupMemory 1GB -MinimumMemory 2GB } | Should Throw;
             }
 
             It 'Throws if "StartupMemory" is greater than "MaximumMemory"' {
-                { Set-LabVMDefaults -StartupMemory 2GB -MaximumMemory 1GB } | Should Throw;
+                { Set-LabVMDefault -StartupMemory 2GB -MaximumMemory 1GB } | Should Throw;
             }
 
             It 'Calls "SetConfigurationData" to write data to disk' {
                 Mock SetConfigurationData -ParameterFilter { $Configuration -eq 'VM' } -MockWith { }
 
-                $defaults = Set-LabVMDefaults;
+                $defaults = Set-LabVMDefault;
 
                 Assert-MockCalled SetConfigurationData -ParameterFilter { $Configuration -eq 'VM' }
             }
 
-        } #end context Validates "Set-LabVMDefaults" method
+        } #end context Validates "Set-LabVMDefault" method
     } #end InModuleScope
 
 } #end describe LabVMDefaults


### PR DESCRIPTION
Fix PSUseSingularNouns warnings and add aliases for old PluralNouns as part of Code Review #30